### PR TITLE
possible bugfix for issue #8

### DIFF
--- a/src/main/java/org/codehaus/mojo/gwt/shell/AbstractGwtShellMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/AbstractGwtShellMojo.java
@@ -194,7 +194,7 @@ public abstract class AbstractGwtShellMojo
         return extra;
     }
 
-    private String getJavaCommand()
+    protected String getJavaCommand()
         throws MojoExecutionException
     {
         if ( StringUtils.isEmpty( jvm ) )


### PR DESCRIPTION
I have added a function which executes a "java -showversion" command against the jvm that will be used by gwt build.  If the output from this command contains the string "IBM" then return true.

I have tested this in our setup, and it appears to be working ok (Win7, Eclipse 64bit), but not tested on linux etc...
