### PR TITLE
Add support for -XdisableRunAsync

### DIFF
--- a/src/main/java/org/codehaus/mojo/gwt/shell/CompileMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/CompileMojo.java
@@ -124,6 +124,16 @@ public class CompileMojo
     private boolean disableCastChecking;
 
     /**
+     * EXPERIMENTAL: Disables code-splitting.
+     * <p>
+     * Can be set from command line using '-Dgwt.disableRunAsync=true'.
+     * </p>
+     *
+     * @parameter default-value="false" expression="${gwt.disableRunAsync}"
+     */
+    private boolean disableRunAsync;
+
+    /**
      * Validate all source code, but do not compile.
      * <p>
      * Can be set from command line using '-Dgwt.validateOnly=true'.
@@ -255,7 +265,9 @@ public class CompileMojo
             .arg( enableAssertions, "-ea" ).arg( draftCompile, "-draftCompile" )
             .arg( validateOnly, "-validateOnly" ).arg( treeLogger, "-treeLogger" )
             .arg( disableClassMetadata, "-XdisableClassMetadata" )
-            .arg( disableCastChecking, "-XdisableCastChecking" ).arg( strict, "-strict" )
+            .arg( disableCastChecking, "-XdisableCastChecking" )
+            .arg( disableRunAsync, "-XdisableRunAsync" )
+            .arg( strict, "-strict" )
             .arg( soycDetailed, "-XsoycDetailed" );
 
 


### PR DESCRIPTION
I followed the same pattern as -XdisableCastChecking and -XdisableClassMetadata.

It occurs to me that it might be better to instead support <extraGwtArgs>, so that arbitrary additional flags, not already supported by gwt-maven-plugin could be provided. If you'd prefer to take this approach, let me know and I'll submit a patch for that instead.
