### PR TITLE
The annotation RemoteServiceRelativePath should be scanned from the service interfaces rather than the implementations.

### DIFF
--- a/src/it/mergewebxmlmojoannotation/src/main/java/org/codehaus/mojo/gwt/test/client/HelloService.java
+++ b/src/it/mergewebxmlmojoannotation/src/main/java/org/codehaus/mojo/gwt/test/client/HelloService.java
@@ -25,7 +25,7 @@ import java.util.List;
 import com.google.gwt.user.client.rpc.RemoteService;
 import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 
-@RemoteServiceRelativePath( "Hello" )
+@RemoteServiceRelativePath( "/HelloService" )
 public interface HelloService
     extends RemoteService
 {

--- a/src/it/mergewebxmlmojoannotation/src/main/java/org/codehaus/mojo/gwt/test/server/HelloRemoteServlet.java
+++ b/src/it/mergewebxmlmojoannotation/src/main/java/org/codehaus/mojo/gwt/test/server/HelloRemoteServlet.java
@@ -26,10 +26,8 @@ import javax.servlet.ServletException;
 
 import org.codehaus.mojo.gwt.test.client.HelloService;
 
-import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 import com.google.gwt.user.server.rpc.RemoteServiceServlet;
 
-@RemoteServiceRelativePath(value="/HelloService")
 public class HelloRemoteServlet
     extends RemoteServiceServlet
     implements HelloService

--- a/src/main/java/org/codehaus/mojo/gwt/webxml/ServletAnnotationFinder.java
+++ b/src/main/java/org/codehaus/mojo/gwt/webxml/ServletAnnotationFinder.java
@@ -30,7 +30,10 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.core.type.classreading.MetadataReader;
+import org.springframework.core.type.classreading.MetadataReaderFactory;
 import org.springframework.core.type.classreading.SimpleMetadataReaderFactory;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.core.type.ClassMetadata;
 import org.springframework.util.ClassUtils;
 
 import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
@@ -52,6 +55,57 @@ public class ServletAnnotationFinder
     {
         // no op
     }
+
+	private MetadataReader getMetadataReader(String className,
+											 MetadataReaderFactory factory,
+											 PathMatchingResourcePatternResolver resourceResolver)
+		throws IOException
+	{
+		String resourcePath = ClassUtils.convertClassNameToResourcePath(className);
+		Resource resource = resourceResolver.getResource(resourcePath + ".class");
+		if (resource.exists()) {
+			return factory.getMetadataReader(resource);
+		}
+		return null;
+	}
+
+	private boolean extendsRemoteServlet(ClassMetadata classMetadata,
+										 MetadataReaderFactory factory,
+										 PathMatchingResourcePatternResolver resourceResolver)
+		throws IOException
+	{
+		if (classMetadata.hasSuperClass()) {
+			String name = classMetadata.getSuperClassName();
+			if (name.equals("com.google.gwt.user.server.rpc.RemoteServiceServlet")) {
+				return true;
+			}
+			MetadataReader r = getMetadataReader(classMetadata.getSuperClassName(), factory, resourceResolver);
+			return extendsRemoteServlet(r.getClassMetadata(), factory, resourceResolver);
+		}
+		return false;
+	}
+
+	private AnnotationMetadata getAnnotationMetadataIfServlet(MetadataReader metadataReader,
+															  MetadataReaderFactory factory,
+															  PathMatchingResourcePatternResolver resourceResolver)
+	{
+		ClassMetadata classMetadata = metadataReader.getClassMetadata();
+
+		try {
+			if (classMetadata.isConcrete() && extendsRemoteServlet(classMetadata, factory, resourceResolver)) {
+				for (String i : metadataReader.getClassMetadata().getInterfaceNames()) {
+					MetadataReader r = getMetadataReader(i, factory, resourceResolver);
+					if (r != null && r.getAnnotationMetadata()
+						.hasAnnotation( RemoteServiceRelativePath.class.getName() )) {
+						return r.getAnnotationMetadata();
+					}
+				}
+			}
+		} catch (IOException e) {
+			getLogger().warn("Failed to read class metadata: " + e);
+		}
+		return null;
+	}
 
     /**
      * @param packageName
@@ -75,9 +129,12 @@ public class ServletAnnotationFinder
             getLogger().debug( "springresource " + resource.getFilename() );
             MetadataReader metadataReader = simpleMetadataReaderFactory.getMetadataReader( resource );
 
-            if ( metadataReader.getAnnotationMetadata().hasAnnotation( RemoteServiceRelativePath.class.getName() ) )
+			AnnotationMetadata annotationMetadata = getAnnotationMetadataIfServlet(metadataReader,
+																				   simpleMetadataReaderFactory,
+																				   pathMatchingResourcePatternResolver);
+            if ( annotationMetadata != null )
             {
-                Map<String, Object> annotationAttributes = metadataReader.getAnnotationMetadata()
+                Map<String, Object> annotationAttributes = annotationMetadata
                     .getAnnotationAttributes( RemoteServiceRelativePath.class.getName() );
                 getLogger().debug( "found RemoteServiceRelativePath annotation for class "
                                        + metadataReader.getClassMetadata().getClassName() );

--- a/src/test/java/org/codehaus/mojo/gwt/servlets/HelloRemoteService.java
+++ b/src/test/java/org/codehaus/mojo/gwt/servlets/HelloRemoteService.java
@@ -1,0 +1,20 @@
+package org.codehaus.mojo.gwt.servlets;
+
+import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
+import com.google.gwt.user.client.rpc.RemoteService;
+
+import java.util.Collection;
+import java.util.List;
+
+@RemoteServiceRelativePath(value="/HelloService")
+public interface HelloRemoteService extends RemoteService {
+
+    Collection<Integer> returnsGenerics( List<String> values );
+
+    int returnsPrimitive( String[] values );
+
+    void returnsVoid( String value );
+
+    String[] returnsArray( String[] values );
+
+}

--- a/src/test/java/org/codehaus/mojo/gwt/servlets/HelloRemoteServlet.java
+++ b/src/test/java/org/codehaus/mojo/gwt/servlets/HelloRemoteServlet.java
@@ -24,12 +24,10 @@ import java.util.List;
 
 import javax.servlet.ServletException;
 
-import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 import com.google.gwt.user.server.rpc.RemoteServiceServlet;
 
-@RemoteServiceRelativePath(value="/HelloService")
 public class HelloRemoteServlet
-    extends RemoteServiceServlet
+    extends RemoteServiceServlet implements HelloRemoteService
 {
     public void init()
         throws ServletException
@@ -47,16 +45,19 @@ public class HelloRemoteServlet
         return null;
     }
 
+	@Override
     public int returnsPrimitive( String[] values )
     {
         return 0;
     }
 
+	@Override
     public void returnsVoid( String value )
     {
 
     }
 
+	@Override
     public String[] returnsArray( String[] values )
     {
         return new String[0];


### PR DESCRIPTION
Currently, when using the option scanRemoteServiceRelativePathAnnotation, it is assumed that the servlet classes are annotated with such an annotation.  But normally, only the service interface should be annotated.

I have prepared a patch that instead scans the superinterfaces of servlet implementations.
