### PR TITLE
Fix for http://jira.codehaus.org/browse/MGWT-290

### DIFF
--- a/src/main/java/org/codehaus/mojo/gwt/ClasspathBuilder.java
+++ b/src/main/java/org/codehaus/mojo/gwt/ClasspathBuilder.java
@@ -77,9 +77,9 @@ public class ClasspathBuilder
         // addSourceWithActiveProject would make some java sources available to GWT compiler that should not be accessible in
         // a non-reactor build, making the build less deterministic and encouraging bad design.
 
+        items.add( new File( project.getBuild().getOutputDirectory() ) );
         addSources( items, project.getCompileSourceRoots() );
         addResources( items, project.getResources() );
-        items.add( new File( project.getBuild().getOutputDirectory() ) );
 
         // Use our own ClasspathElements fitering, as for RUNTIME we need to include PROVIDED artifacts,
         // that is not the default Maven policy, as RUNTIME is used here to build the GWTShell execution classpath


### PR DESCRIPTION
This patch reorders the entries in the classpath so that the POM
outputDirectory appears first in the classpath and the java and
resources directories next. Otherwise, the maven resource plugin will
indeed filter the resources as asked and put them in the
outputDirectory, but the filtered files will be shadowed by the
original definition in resources directories.
