### PR TITLE
Include public files from resource

### DIFF
--- a/src/main/java/org/codehaus/mojo/gwt/GwtResourcesBaseMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/GwtResourcesBaseMojo.java
@@ -97,15 +97,14 @@ abstract class GwtResourcesBaseMojo
                     sourcesAndResources.addAll( files );
                     count += files.size();
                 }
+                String source = module.getPublic();
+                getLog().debug( "GWT public files from " + name + '.' + source );
+                Collection<ResourceFile> files = getAsResources( module, source, sourcesAndResourcesPath,
+                                                                 "**/*" );
+                sourcesAndResources.addAll( files );
+                count += files.size();
                 getLog().info( count + " source files from GWT module " + name );
             }
-            String source = module.getPublic();
-            getLog().debug( "GWT public files from " + name + '.' + source );
-            Collection<ResourceFile> files = getAsResources( module, source, sourcesAndResourcesPath,
-                                                             "**/*" );
-            sourcesAndResources.addAll( files );
-            count += files.size();
-            getLog().info( count + " source files from GWT module " + name );
             return sourcesAndResources;
         }
         catch ( GwtModuleReaderException e )


### PR DESCRIPTION
"public" node in project description file is not handled by the gwt:resources goal
