### PR TITLE
[MGWT-339] add codeServerPort configuration to gwt:run

### DIFF
--- a/src/main/java/org/codehaus/mojo/gwt/shell/RunMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/RunMojo.java
@@ -97,9 +97,16 @@ public class RunMojo
     /**
      * Runs the embedded GWT server on the specified port.
      *
-     * @parameter default-value="8888"
+     * @parameter default-value="8888" expression="${gwt.port}"
      */
     private int port;
+
+    /**
+     * Runs the code server on the specified port.
+     *
+     * @parameter default-value="9997" expression="${gwt.codeServerPort}"
+     */
+    private int codeServerPort;
 
     /**
      * Specify the location on the filesystem for the generated embedded Tomcat directory.
@@ -348,6 +355,7 @@ public class RunMojo
             .arg( "-war", hostedWebapp.getAbsolutePath() )
             .arg( "-logLevel", getLogLevel() )
             .arg( "-port", Integer.toString( getPort() ) )
+            .arg( "-codeServerPort" , Integer.toString( codeServerPort ))
             .arg( "-startupUrl", getStartupUrl() )
             .arg( noServer, "-noserver" );
 

--- a/src/main/java/org/codehaus/mojo/gwt/shell/SuperDevModeMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/SuperDevModeMojo.java
@@ -51,9 +51,9 @@ public class SuperDevModeMojo extends AbstractGwtShellMojo
     /**
      * The port where the code server will run.
      *
-     * @parameter
+     * @parameter expression="${gwt.codeServerPort}"
      */
-    private Integer port;
+    private Integer codeServerPort;
 
     /**
      * The root of the directory tree where the code server will write compiler output.
@@ -94,9 +94,9 @@ public class SuperDevModeMojo extends AbstractGwtShellMojo
         {
             cmd.arg( "-bindAddress" ).arg( bindAddress );
         }
-        if ( port != null )
+        if ( codeServerPort != null )
         {
-            cmd.arg( "-port", String.valueOf( port ) );
+            cmd.arg( "-port", String.valueOf( codeServerPort ) );
         }
         if ( codeServerWorkDir != null )
         {


### PR DESCRIPTION
Also renames port to codeServerPort in gwt::run-codeserver, so that the
same configuration is used for the purpose, and the port configuration is
only ever used for the embedded HTTP server used for serving the webapp.
