### PR TITLE
[MGWT-326] M2Eclipse integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -312,6 +312,11 @@
       <artifactId>plexus-compiler-api</artifactId>
       <version>1.5.3</version>
     </dependency>
+    <dependency>
+      <groupId>org.sonatype.plexus</groupId>
+      <artifactId>plexus-build-api</artifactId>
+      <version>0.0.7</version>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.maven.shared</groupId>

--- a/src/main/java/org/codehaus/mojo/gwt/shell/CSSMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/CSSMojo.java
@@ -20,8 +20,9 @@ package org.codehaus.mojo.gwt.shell;
  */
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
 import java.util.List;
 
 import org.apache.commons.io.FilenameUtils;
@@ -30,7 +31,9 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.cli.StreamConsumer;
+import org.sonatype.plexus.build.incremental.BuildContext;
 
 /**
  * Creates CSS interfaces for css files.
@@ -58,6 +61,14 @@ public class CSSMojo
      * @parameter
      */
     private String cssFile;
+
+    /**
+     * @parameter expression="${project.build.sourceEncoding}"
+     */
+    private String encoding;
+
+    /** @component */
+    private BuildContext buildContext;
 
     public void doExecute()
         throws MojoExecutionException, MojoFailureException
@@ -89,6 +100,14 @@ public class CSSMojo
                     final File candidate = new File( resource.getDirectory(), file );
                     if ( candidate.exists() )
                     {
+                        if ( buildContext.isUptodate( javaOutput, candidate ) )
+                        {
+                            getLog().debug( javaOutput.getAbsolutePath() + " is up to date. Generation skipped" );
+                            // up to date, but still need to report generated-sources directory as sourceRoot
+                            generated = true;
+                            break;
+                        }
+
                         getLog().info( "Generating " + javaOutput + " with typeName " + typeName );
                         ensureTargetPackageExists( getGenerateDirectory(), typeName );
 
@@ -104,10 +123,14 @@ public class CSSMojo
                             .arg( candidate.getAbsolutePath() )
                             .withinClasspath( getGwtDevJar() )
                             .withinClasspath( getGwtUserJar() )
-                            .execute();                            
-                            final FileWriter outputWriter = new FileWriter( javaOutput );
-                            outputWriter.write( content.toString() );
-                            outputWriter.close();
+                            .execute();
+                            final OutputStreamWriter outputWriter =
+                                new OutputStreamWriter( buildContext.newFileOutputStream( javaOutput ) , encoding );
+                            try {
+                                outputWriter.write( content.toString() );
+                            } finally {
+                                IOUtil.close( outputWriter );
+                            }
                         }
                         catch ( IOException e )
                         {
@@ -134,14 +157,17 @@ public class CSSMojo
     }
 
     private void setup()
-
-        throws MojoExecutionException
     {
+        if ( encoding == null )
+        {
+            getLog().warn( "Encoding is not set, your build will be platform dependent" );
+            encoding = Charset.defaultCharset().name();
+        }
+
         if ( cssFiles == null && cssFile != null )
         {
             cssFiles = new String[] { cssFile };
         }
-
     }
 
     private void ensureTargetPackageExists( File generateDirectory, String targetName )

--- a/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>css</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <execute>
+          <runOnIncremental>true</runOnIncremental>
+          <runOnConfiguration>true</runOnConfiguration>
+        </execute>
+      </action>
+    </pluginExecution>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>generateAsync</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <execute>
+          <runOnIncremental>true</runOnIncremental>
+          <runOnConfiguration>true</runOnConfiguration>
+        </execute>
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>


### PR DESCRIPTION
Uses org.sonatype.plexus:plexus-build-api and adds
lifecycle-mapping-metadata.xml for the css and generateAsync goals.

See http://wiki.eclipse.org/M2E_compatible_maven_plugins

http://jira.codehaus.org/browse/MGWT-326
