### PR TITLE
Fixed typo and warning in generateAsync

### DIFF
--- a/src/main/java/org/codehaus/mojo/gwt/GenerateAsyncMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/GenerateAsyncMojo.java
@@ -239,6 +239,7 @@ public class GenerateAsyncMojo
         writer.println( "import com.google.gwt.user.client.rpc.AsyncCallback;" );
         
 	// prevent unused import warnings
+	String uri = MessageFormat.format( rpcPattern, className );
 	if ( uri != null )
         {
 	    writer.println( "import com.google.gwt.user.client.rpc.ServiceDefTarget;" );	
@@ -322,7 +323,7 @@ public class GenerateAsyncMojo
 
         writer.println();
 
-        String uri = MessageFormat.format( rpcPattern, className );
+
         if ( clazz.getAnnotations() != null )
         {
             for ( Annotation annotation : clazz.getAnnotations() )


### PR DESCRIPTION
I don't like having those pesky Java warnings from unused imports. This fixes that by only including the import when needed.

Also fixed spelling typo, since I don't fancy those warnings either. :)
