### PR TITLE
Handle logLevel in TestMojo

### DIFF
--- a/src/main/java/org/codehaus/mojo/gwt/shell/TestMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/TestMojo.java
@@ -301,6 +301,7 @@ public class TestMojo
     {
         StringBuilder sb = new StringBuilder();
         sb.append( "-out " ).append( out );
+        sb.append( " -logLevel " ).append( getLogLevel() );
         if ( webMode )
         {
             sb.append( " -web" );


### PR DESCRIPTION
As written [here](https://groups.google.com/forum/?fromgroups#!topic/google-web-toolkit/5HUqCGTJEyg) the TestMojo currently doesn't handle the logLevel parameter.

This pull request adds this functionality.
