### PR TITLE
gwt:eclipse fix - generates valid .launch file, and writes Google Plugin attributes.

### DIFF
--- a/src/main/java/org/codehaus/mojo/gwt/eclipse/EclipseMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/eclipse/EclipseMojo.java
@@ -259,6 +259,8 @@ public class EclipseMojo
                 page += "?" + additionalPageParameters;
             }
 
+            context.put( "noserver", !noserver ? "true" : "false" );
+            context.put( "port", "" + port );
             context.put( "modulePath", readModule( module ).getPath() );
             context.put( "page", page );
             int basedir = getProject().getBasedir().getAbsolutePath().length();

--- a/src/main/resources/org/codehaus/mojo/gwt/eclipse/google.fm
+++ b/src/main/resources/org/codehaus/mojo/gwt/eclipse/google.fm
@@ -7,7 +7,11 @@
   <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
     <listEntry value="4"/>
   </listAttribute>
+  <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.google.gwt.dev.DevMode"/>
   <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="com.google.gwt.eclipse.core.moduleClasspathProvider"/>
   <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="${project}"/>
   <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dgwt.nowarn.legacy.tools"/>
+  <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-war ${war} ${additionalArguments} -startupUrl ${page} ${module}"/>
+  <booleanAttribute key="com.google.gdt.eclipse.core.RUN_SERVER" value="${noserver}"/>
+  <stringAttribute key="com.google.gdt.eclipse.core.SERVER_PORT" value="${port}"/>
 </launchConfiguration>


### PR DESCRIPTION
This is a simple fix that unbreaks the gwt:eclipse goal when useGoogleEclipsePlugin=true (the default).
It produces what I believe was intended in the first place, but never appears to have worked properly.
