### PR TITLE
MGWT-366 gwt:eclipse fix - generates valid .launch file (improved)

### DIFF
--- a/src/main/java/org/codehaus/mojo/gwt/eclipse/EclipseMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/eclipse/EclipseMojo.java
@@ -259,12 +259,14 @@ public class EclipseMojo
                 page += "?" + additionalPageParameters;
             }
 
+            context.put( "noserver", !noserver ? "true" : "false" );
+            context.put( "port", "" + port );
             context.put( "modulePath", readModule( module ).getPath() );
             context.put( "page", page );
             int basedir = getProject().getBasedir().getAbsolutePath().length();
             context.put( "out", getOutputDirectory().getAbsolutePath().substring( basedir + 1 ) );
             context.put( "war", hostedWebapp.getAbsolutePath().substring( basedir + 1 ) );
-            String args = noserver ? "-noserver -port " + port : "";
+            String args = noserver ? "-noserver" : " -port " + port;
             if ( blacklist != null )
             {
                 args += " -blacklist " + blacklist;

--- a/src/main/resources/org/codehaus/mojo/gwt/eclipse/google.fm
+++ b/src/main/resources/org/codehaus/mojo/gwt/eclipse/google.fm
@@ -7,7 +7,11 @@
   <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
     <listEntry value="4"/>
   </listAttribute>
-  <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="com.google.gwt.eclipse.core.moduleClasspathProvider"/>
+  <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.google.gwt.dev.DevMode"/>
+  <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="com.google.gdt.eclipse.maven.mavenClasspathProvider"/>
   <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="${project}"/>
   <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dgwt.nowarn.legacy.tools"/>
+  <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-remoteUI &quot;${r"${gwt_remote_ui_server_port}:${unique_id}&quot;"} -war ${war} ${additionalArguments} -startupUrl ${page} ${module}"/>
+  <booleanAttribute key="com.google.gdt.eclipse.core.RUN_SERVER" value="${noserver}"/>
+  <#if noserver != "false"><stringAttribute key="com.google.gdt.eclipse.core.SERVER_PORT" value="${port}"/></#if>
 </launchConfiguration>


### PR DESCRIPTION
Improved fix for MGWT-366, behaves much more pleasantly if you sneak up on it.  Prevents port warnings when in noserver mode (a bug in the original code that passes -port along with noserver), uses the correct classpath provider.