### PR TITLE
Fix to integrate generated source folder with eclipse java build path au...

### DIFF
--- a/src/main/java/org/codehaus/mojo/gwt/GenerateAsyncMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/GenerateAsyncMojo.java
@@ -140,10 +140,8 @@ public class GenerateAsyncMojo
         // add the generated source into compile source
         // do this step first to ensure the source folder will be added to the Eclipse classpath
         // Solution inspired by CXF codegen plugin 
-        if (getGenerateDirectory() != null) {
-            getLog().info( "Anticipate addition of generated directory for automatic integration in eclipse" );
-            addCompileSourceRoot( getGenerateDirectory() );
-        }
+        getLog().info( "Anticipate addition of generated directory for automatic integration in eclipse" );
+        addCompileSourceRoot( getGenerateDirectory() );
 
 
         if ( encoding == null )


### PR DESCRIPTION
Patch to integrate generated source folder with eclipse java build path automatically,
as explained on issue https://github.com/gwt-maven-plugin/gwt-maven-plugin/issues/65
