### PR TITLE
- makes run-codeserver MOJO aware of Maven project of the preceding process-classes execution

### DIFF
--- a/src/main/java/org/codehaus/mojo/gwt/shell/SuperDevModeMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/SuperDevModeMojo.java
@@ -22,6 +22,8 @@ package org.codehaus.mojo.gwt.shell;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.mojo.gwt.MavenProjectContext;
 
 import java.io.File;
 
@@ -88,6 +90,12 @@ public class SuperDevModeMojo extends AbstractGwtShellMojo
      */
     private String sourceLevel;
 
+    /**
+     * The MavenProject executed by the "process-classes" phase.
+     * @parameter expression="${executedProject}"
+     */
+    private MavenProject executedProject;
+    
     @Override
     public void doExecute()
         throws MojoExecutionException, MojoFailureException
@@ -135,6 +143,17 @@ public class SuperDevModeMojo extends AbstractGwtShellMojo
         }
 
         cmd.execute();
+    }
+    
+    public void setExecutedProject( MavenProject executedProject )
+    {
+        this.executedProject = executedProject;
+    }
+    
+    @Override
+    public MavenProject getProject()
+    {
+        return executedProject;
     }
 }
 


### PR DESCRIPTION
This is a proposed fix for https://jira.codehaus.org/browse/MGWT-345 by making the affected run-codeserver MOJO aware of the forked process-classes build which in turn adds the compile source roots. See http://books.sonatype.com/mvnref-book/reference/writing-plugins-sect-custom-plugin.html regarding the "@execute" annotation. ITs were not run since I use Maven 3.1.0 which breaks reporting API (see https://cwiki.apache.org/confluence/display/MAVEN/AetherClassNotFound) but the run-codeserver MOJO correctly picks up the generated "async" interfaces, "i18n" etc.
