### PR TITLE
Typo in comment in generated async interface

### DIFF
--- a/src/main/java/org/codehaus/mojo/gwt/GenerateAsyncMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/GenerateAsyncMojo.java
@@ -347,7 +347,7 @@ public class GenerateAsyncMojo
         writer.println( "" );
         writer.println( "        private Util()" );
         writer.println( "        {" );
-        writer.println( "            // Utility class should not be instanciated" );
+        writer.println( "            // Utility class should not be instantiated" );
         writer.println( "        }" );
         writer.println( "    }" );
 


### PR DESCRIPTION
Just a minor typo, since it happens inside a comment.
But would be great to have it fixed.

Hey and thanks for the plugin, it saved me a lot of time during development with GWT.
