### PR TITLE
Add configuration option 'additionalSources' to run and run-codeserver

### DIFF
--- a/src/main/java/org/codehaus/mojo/gwt/shell/AbstractGwtShellMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/AbstractGwtShellMojo.java
@@ -197,9 +197,9 @@ public abstract class AbstractGwtShellMojo
     }
 
     /**
-     * hook to post-process the dependency-based classpath
+     * Hook to post-process the dependency-based classpath.
      */
-    protected void postProcessClassPath( Collection<File> classpath )
+    protected void postProcessClassPath( List<File> classpath )
         throws MojoExecutionException
     {
         // Nothing to do in most case

--- a/src/main/java/org/codehaus/mojo/gwt/shell/RunMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/RunMojo.java
@@ -23,11 +23,7 @@ import static org.codehaus.plexus.util.AbstractScanner.DEFAULTEXCLUDES;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Pattern;
 
 import org.apache.maven.artifact.Artifact;
@@ -249,6 +245,13 @@ public class RunMojo
      */
     private String sourceLevel = System.getProperty("java.specification.version");
 
+    /**
+     * Additional classpath entries to prepend to the classpath.
+     *
+     * @parameter
+     */
+    private File[] additionalSources;
+
     public String getRunTarget()
     {
         return this.runTarget;
@@ -410,8 +413,14 @@ public class RunMojo
     }
 
     @Override
-    protected void postProcessClassPath( Collection<File> classPath )
+    protected void postProcessClassPath( List<File> classPath )
     {
+        // Prepend additional classpath entries to the final classpath.
+        if ( additionalSources != null && additionalSources.length > 0 )
+        {
+            classPath.addAll( 0, Arrays.asList( additionalSources ) );
+        }
+
         boolean isAppEngine = "com.google.appengine.tools.development.gwt.AppEngineLauncher".equals( server );
         List<Pattern> patternsToExclude = new ArrayList<Pattern>();
         if ( runClasspathExcludes != null && !runClasspathExcludes.isEmpty() )

--- a/src/main/java/org/codehaus/mojo/gwt/shell/SuperDevModeMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/SuperDevModeMojo.java
@@ -26,6 +26,8 @@ import org.apache.maven.project.MavenProject;
 import org.codehaus.mojo.gwt.MavenProjectContext;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * EXPERIMENTAL: Runs GWT modules with Super Dev Mode.
@@ -91,6 +93,13 @@ public class SuperDevModeMojo extends AbstractGwtShellMojo
     private String sourceLevel;
 
     /**
+     * Additional classpath entries to prepend to the classpath.
+     *
+     * @parameter
+     */
+    private File[] additionalSources;
+
+    /**
      * The MavenProject executed by the "process-classes" phase.
      * @parameter expression="${executedProject}"
      */
@@ -144,7 +153,16 @@ public class SuperDevModeMojo extends AbstractGwtShellMojo
 
         cmd.execute();
     }
-    
+
+    @Override
+    protected void postProcessClassPath( List<File> classPath )
+    {
+        // Prepend additional classpath entries to the final classpath.
+        if ( additionalSources != null && additionalSources.length > 0 ) {
+            classPath.addAll( 0, Arrays.asList( additionalSources ) );
+        }
+    }
+
     public void setExecutedProject( MavenProject executedProject )
     {
         this.executedProject = executedProject;

--- a/src/main/java/org/codehaus/mojo/gwt/shell/TestMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/TestMojo.java
@@ -551,7 +551,7 @@ public class TestMojo
     }
 
     @Override
-    protected void postProcessClassPath( Collection<File> classpath )
+    protected void postProcessClassPath( List<File> classpath )
         throws MojoExecutionException
     {
         classpath.add( getClassPathElementFor( TestMojo.class ) );


### PR DESCRIPTION
Add configuration option 'additionalSources' to run and run-codeserver goals. This makes it possible to supply extra classpath entries that will be prepended to the classpath.

Improved commit according to comment in https://github.com/gwt-maven-plugin/gwt-maven-plugin/pull/80.