### PR TITLE
Fix for GWT XML files not being resolved from compileSourceArtifacts

### DIFF
--- a/src/main/java/org/codehaus/mojo/gwt/AbstractGwtModuleMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/AbstractGwtModuleMojo.java
@@ -41,7 +41,6 @@ import org.codehaus.mojo.gwt.utils.DefaultGwtModuleReader;
 import org.codehaus.mojo.gwt.utils.GwtModuleReaderException;
 import org.codehaus.plexus.util.DirectoryScanner;
 import org.codehaus.plexus.util.ReaderFactory;
-import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 
@@ -76,7 +75,7 @@ public abstract class AbstractGwtModuleMojo
      * @parameter expression="${gwt.module}"
      */
     private String module;
-
+    
     /**
      *
      * Artifacts to be included as source-jars in GWTCompiler Classpath. Removes the restriction that source code must
@@ -194,7 +193,7 @@ public abstract class AbstractGwtModuleMojo
                 return readModule( name, xml );
             }
         }
-
+        
         try
         {
             Collection<File> classpath = getClasspath(Artifact.SCOPE_COMPILE );
@@ -218,51 +217,8 @@ public abstract class AbstractGwtModuleMojo
             throw new GwtModuleReaderException(e.getMessage(), e);
         }
 
+
         throw new GwtModuleReaderException( "GWT Module " + name + " not found in project sources or resources." );
-    }
-
-    @Override
-    public Collection<File> getClasspath(String scope) throws MojoExecutionException {
-    	
-    	Collection<File> files = super.getClasspath(scope);
-    	
-    	if (compileSourcesArtifacts == null) {
-            return files;
-        }
-        
-        for (String include : compileSourcesArtifacts) {
-        	
-            List<String> parts = new ArrayList<String>();
-            
-            parts.addAll( Arrays.asList(include.split(":")) );
-            
-            if (parts.size() == 2) {
-                // type is optional as it will mostly be "jar"
-                parts.add("jar");
-            }
-            
-            String dependencyId = StringUtils.join(parts.iterator(), ":");
-            
-            boolean found = false;
-
-            for (Artifact artifact : getProjectArtifacts()) {
-                getLog().debug("compare " + dependencyId + " with " + artifact.getDependencyConflictId());
-                
-                if (artifact.getDependencyConflictId().equals(dependencyId)) {
-                    getLog().debug( "Add " + dependencyId + " sources.jar artifact to compile classpath" );
-                    Artifact sources = resolve(artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion(), "jar", "sources");
-                    files.add(sources.getFile());
-                    found = true;
-                    break;
-                }
-            }
-            
-            if ( !found ) {
-                getLog().warn("Declared compileSourcesArtifact was not found in project dependencies " + dependencyId);
-            }
-        }
-    	    	
-    	return files;
     }
     
     private GwtModule readModule( String name, File file )

--- a/src/main/java/org/codehaus/mojo/gwt/AbstractGwtMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/AbstractGwtMojo.java
@@ -29,6 +29,7 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -98,6 +99,11 @@ public abstract class AbstractGwtMojo
      * @component
      */
     protected ClasspathBuilder classpathBuilder;
+
+    /**
+     * Resolved source artifacts
+     */
+    protected Iterable<Artifact> resolvedCompileSourceArtifacts;
 
     // --- Some MavenSession related structures --------------------------------
 
@@ -232,6 +238,10 @@ public abstract class AbstractGwtMojo
         {
             Collection<File> files = classpathBuilder.buildClasspathList( getProject(), scope, getProjectArtifacts(), isGenerator() );
 
+        	for (Artifact artifact : getResolvedCompileSourceArtifacts()) {
+        		files.add(artifact.getFile());
+        	}
+        	
             if ( getLog().isDebugEnabled() )
             {
                 getLog().debug( "GWT SDK execution classpath :" );
@@ -240,6 +250,7 @@ public abstract class AbstractGwtMojo
                     getLog().debug( "   " + f.getAbsolutePath() );
                 }
             }
+            
             return files;
         }
         catch ( ClasspathBuilderException e )
@@ -248,6 +259,18 @@ public abstract class AbstractGwtMojo
         }
     }
 
+    protected Iterable<Artifact> getResolvedCompileSourceArtifacts() {
+    	
+    	if (resolvedCompileSourceArtifacts == null) {
+    		return Collections.emptySet();
+    	}
+    	
+		return resolvedCompileSourceArtifacts;
+	}
+
+    protected void setResolvedCompileSourceArtifacts(Iterable<Artifact> artifacts) {
+		this.resolvedCompileSourceArtifacts = artifacts;
+	}
 
     /**
      * Whether to use processed resources and compiled classes ({@code false}), or raw resources ({@code true }).

--- a/src/main/java/org/codehaus/mojo/gwt/shell/AbstractGwtShellMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/AbstractGwtShellMojo.java
@@ -144,7 +144,7 @@ public abstract class AbstractGwtShellMojo
      * @since 2.5.0-rc1
      */
     private File persistentunitcachedir;
-
+ 
     // methods
 
     /**
@@ -255,9 +255,11 @@ public abstract class AbstractGwtShellMojo
         {
             return;
         }
+
+        List<Artifact> compileSourceArtifacts = new ArrayList<Artifact>();
         
-        for ( String include : compileSourcesArtifacts )
-        {
+        for ( String include : compileSourcesArtifacts ) {
+        	
             List<String> parts = new ArrayList<String>();
             parts.addAll( Arrays.asList(include.split(":")) );
             if ( parts.size() == 2 )
@@ -277,15 +279,22 @@ public abstract class AbstractGwtShellMojo
                     Artifact sources =
                             resolve( artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion(),
                                     "jar", "sources" );
+
+                    compileSourceArtifacts.add(sources);
+                    
                     cmd.withinClasspath( sources.getFile() );
                     found = true;
                     break;
                 }
             }
+            
             if ( !found )
                 getLog().warn(
                         "Declared compileSourcesArtifact was not found in project dependencies " + dependencyId );
         }
+
+        setResolvedCompileSourceArtifacts(compileSourceArtifacts);
+        
     }
 
     protected void addArgumentDeploy(JavaCommand cmd) {
@@ -318,7 +327,7 @@ public abstract class AbstractGwtShellMojo
         }
     }
 
-    /**
+	/**
      * A plexus-util StreamConsumer to redirect messages to plugin log
      */
     protected StreamConsumer out = new StreamConsumer()

--- a/src/main/java/org/codehaus/mojo/gwt/shell/AbstractGwtShellMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/AbstractGwtShellMojo.java
@@ -124,20 +124,6 @@ public abstract class AbstractGwtShellMojo
      * @parameter
      */
     private int timeOut;
-    /**
-     *
-     * Artifacts to be included as source-jars in GWTCompiler Classpath. Removes the restriction that source code must
-     * be bundled inside of the final JAR when dealing with external utility libraries not designed exclusivelly for
-     * GWT. The plugin will download the source.jar if necessary.
-     *
-     * This option is a workaround to avoid packaging sources inside the same JAR when splitting and application into
-     * modules. A smaller JAR can then be used on server classpath and distributed without sources (that may not be
-     * desirable).
-     *
-     *
-     * @parameter
-     */
-    private String[] compileSourcesArtifacts;
 
     /**
      * Whether to use the persistent unit cache or not.
@@ -269,6 +255,7 @@ public abstract class AbstractGwtShellMojo
         {
             return;
         }
+        
         for ( String include : compileSourcesArtifacts )
         {
             List<String> parts = new ArrayList<String>();

--- a/src/main/java/org/codehaus/mojo/gwt/shell/CompileMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/CompileMojo.java
@@ -453,7 +453,7 @@ public class CompileMojo
         {
             return localWorkers;
         }
-        // workaround to GWT issue 4031 whith IBM JDK
+        // workaround to GWT issue 4031 with IBM JDK
         // @see http://code.google.com/p/google-web-toolkit/issues/detail?id=4031
         if ( System.getProperty( "java.vendor" ).startsWith( "IBM" ) && StringUtils.isEmpty(getJvm()))
         {


### PR DESCRIPTION
The readModule() method doesn't include the compileSourceArtifacts and so is unable to resolve the GWT XML files regardless of whether the sources have been correctly added to the compile classpath.

I've overridden the getClassPath() method and moved the property "String[] compileSourceArtifacts" into the parent class (I had to change this from private to protected).

This has fixed the issue that we have in that our published API jars don't contain the GWT XML files but the sources obviously do.