### PR TITLE
Expose the gwt.coverage flag in the gwt-maven-plugin

### DIFF
--- a/src/it/compile-with-coverage/invoker.properties
+++ b/src/it/compile-with-coverage/invoker.properties
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+invoker.goals=clean package

--- a/src/it/compile-with-coverage/pom.xml
+++ b/src/it/compile-with-coverage/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.codehaus.mojo.gwt.it</groupId>
+  <artifactId>gwt-compile-with-coverage</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>war</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>gwt-maven-plugin</artifactId>
+        <version>@pom.version@</version>
+        <configuration>
+          <genParam>false</genParam>
+          <inplace>true</inplace>
+          <logLevel>INFO</logLevel>
+          <style>OBF</style>
+          <draftCompile>true</draftCompile>
+          <optimizationLevel>1</optimizationLevel>
+          <extraParam>true</extraParam>
+          <soyc>false</soyc>
+          <failOnError>true</failOnError>
+          <workDir>${project.build.directory}/workDir</workDir>
+          <deploy>${project.build.directory}/deploy</deploy>
+          <persistentunitcache>true</persistentunitcache>
+          <persistentunitcachedir>${project.build.directory}/persistentunitcache</persistentunitcachedir>
+          <enableClosureCompiler>true</enableClosureCompiler>
+          <disableAggressiveOptimization>true</disableAggressiveOptimization>
+          <compilerMetrics>true</compilerMetrics>
+          <fragmentCount>2</fragmentCount>
+          <clusterFunctions>false</clusterFunctions>
+          <enforceStrictResources>true</enforceStrictResources>
+          <inlineLiteralParameters>false</inlineLiteralParameters>
+          <optimizeDataflow>false</optimizeDataflow>
+          <ordinalizeEnums>false</ordinalizeEnums>
+          <removeDuplicateFunctions>false</removeDuplicateFunctions>
+          <saveSource>true</saveSource>
+          <saveSourceOutput>${project.build.directory}/savedSources</saveSourceOutput>
+          <incrementalCompileWarnings>true</incrementalCompileWarnings>
+          <missingDepsFile>${project.build.directory}/missingDeps</missingDepsFile>
+          <jsInteropMode>JS</jsInteropMode>
+          <namespace>NONE</namespace>
+          <overlappingSourceWarnings>true</overlappingSourceWarnings>
+          <methodNameDisplayMode>FULL</methodNameDisplayMode>
+          <coverage>
+            <enabled>true</enabled>
+            <scanDependencies>true</scanDependencies>
+            <includes>
+              <include>org/codehaus/mojo/gwt/test/**/*.java</include>
+              <include>com/google/gwt/core/client/**/*.java</include>
+            </includes>
+            <excludes>
+              <exclude>**/server/**</exclude>
+            </excludes>
+          </coverage>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generateAsync</goal>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.gwt</groupId>
+      <artifactId>gwt-user</artifactId>
+      <version>@gwt.version@</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/compile-with-coverage/src/main/java/org/codehaus/mojo/gwt/test/Hello.gwt.xml
+++ b/src/it/compile-with-coverage/src/main/java/org/codehaus/mojo/gwt/test/Hello.gwt.xml
@@ -1,0 +1,29 @@
+<!--
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+-->
+<!DOCTYPE module PUBLIC "//gwt-module/" "http://google-web-toolkit.googlecode.com/svn/tags/2.1.0-rc1/distro-source/core/src/gwt-module.dtd">
+<module rename-to="hello">
+  <inherits name="com.google.gwt.user.User"/>
+  <source path="client"/>
+  <public path="public"/>
+  <entry-point class="org.codehaus.mojo.gwt.test.client.Hello"/>
+  <servlet path="/HelloService" class="org.codehaus.mojo.gwt.test.server.HelloRemoteServlet"/>
+  <set-property name="user.agent" value="gecko1_8"/>  
+</module>

--- a/src/it/compile-with-coverage/src/main/java/org/codehaus/mojo/gwt/test/client/Hello.java
+++ b/src/it/compile-with-coverage/src/main/java/org/codehaus/mojo/gwt/test/client/Hello.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.codehaus.mojo.gwt.test.client;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import com.google.gwt.core.client.EntryPoint;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.RootPanel;
+
+public class Hello
+    implements EntryPoint
+{
+
+    public void onModuleLoad()
+    {
+
+        RootPanel.get().add( new Label( "GWT is running :D" ) );
+        HelloServiceAsync service = HelloServiceAsync.Util.getInstance();
+
+        service.exit( new VoidAsyncCallBack() );
+
+        /**
+         *  Asycn method invocations to check generated code matches the expected signatures.
+         *  Generation mismatch will be detected during compile phase by the java compiler
+         */
+        
+        service.returnsVoid( "test", new VoidAsyncCallBack() );
+        
+        service.returnsPrimitive( new String[0], new IntegerAsyncCallBack() );
+        
+        service.returnsGenerics( new ArrayList<String>(), new CollectionAsynCallBack() );
+    }
+
+    private final class CollectionAsynCallBack
+        implements AsyncCallback<Collection<Integer>>
+    {
+        public void onFailure( Throwable caught )
+        {
+            // TODO Auto-generated method stub
+
+        }
+
+        public void onSuccess( Collection<Integer> result )
+        {
+        }
+    }
+
+    private final class IntegerAsyncCallBack
+        implements AsyncCallback<Integer>
+    {
+        public void onFailure( Throwable caught )
+        {
+            // TODO Auto-generated method stub
+
+        }
+
+        public void onSuccess( Integer result )
+        {
+        }
+    }
+
+    private final class VoidAsyncCallBack
+        implements AsyncCallback<Void>
+    {
+        public void onFailure( Throwable caught )
+        {
+
+        }
+
+        public void onSuccess( Void result )
+        {
+
+        }
+    }
+}

--- a/src/it/compile-with-coverage/src/main/java/org/codehaus/mojo/gwt/test/client/HelloService.java
+++ b/src/it/compile-with-coverage/src/main/java/org/codehaus/mojo/gwt/test/client/HelloService.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.codehaus.mojo.gwt.test.client;
+
+import java.util.Collection;
+import java.util.List;
+
+import com.google.gwt.user.client.rpc.RemoteService;
+import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
+
+@RemoteServiceRelativePath( "Hello" )
+public interface HelloService
+    extends RemoteService
+{
+    void exit();
+
+    // expected : void returnsVoid( String value, AsyncCallback<Void> callback );
+    void returnsVoid( String value );
+
+    // expected : void returnsPrimitive( String[] values, AsyncCallback<Integer> callback );
+    int returnsPrimitive( String[] values );
+
+    // expected : void returnsArray( String[] values, AsyncCallback<String[]> callback );
+    String[] returnsArray( String[] values );
+
+    // expected : void returnsGenerics( java.util.List<String> values, AsyncCallback<java.util.Collection<Integer>>
+    // callback );
+    Collection<Integer> returnsGenerics( List<String> values );
+}

--- a/src/it/compile-with-coverage/src/main/java/org/codehaus/mojo/gwt/test/public/Hello.html
+++ b/src/it/compile-with-coverage/src/main/java/org/codehaus/mojo/gwt/test/public/Hello.html
@@ -1,0 +1,30 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!--
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */ 
+ --> 
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <title>Hello</title>
+  </head>
+  <body bgcolor="white"> 
+    <script type="text/javascript" language="javascript" src="hello.nocache.js"></script>
+  </body>
+</html>

--- a/src/it/compile-with-coverage/src/main/java/org/codehaus/mojo/gwt/test/server/HelloRemoteServlet.java
+++ b/src/it/compile-with-coverage/src/main/java/org/codehaus/mojo/gwt/test/server/HelloRemoteServlet.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.codehaus.mojo.gwt.test.server;
+
+import java.util.Collection;
+import java.util.List;
+
+import javax.servlet.ServletException;
+
+import org.codehaus.mojo.gwt.test.client.HelloService;
+
+import com.google.gwt.user.server.rpc.RemoteServiceServlet;
+
+public class HelloRemoteServlet
+    extends RemoteServiceServlet
+    implements HelloService
+{
+    public void init()
+        throws ServletException
+    {
+        System.out.println( "HelloRemoteServlet started" );
+    }
+
+
+    public void exit()
+    {
+        // Kill the JVM to stop the Hosted server
+        System.exit( 0 );
+    }
+
+    public Collection<Integer> returnsGenerics( List<String> values )
+    {
+        return null;
+    }
+
+    public int returnsPrimitive( String[] values )
+    {
+        return 0;
+    }
+
+    public void returnsVoid( String value )
+    {
+
+    }
+
+    public String[] returnsArray( String[] values )
+    {
+        return new String[0];
+    }
+
+
+}

--- a/src/it/compile-with-coverage/src/main/webapp/WEB-INF/web.xml
+++ b/src/it/compile-with-coverage/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<web-app xmlns="http://java.sun.com/xml/ns/j2ee" version="2.4" 
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
+  
+	<servlet>
+	  <servlet-name>hello</servlet-name>
+	  <servlet-class>org.codehaus.mojo.gwt.test.server.HelloRemoteServlet</servlet-class>
+	</servlet>
+  
+    <servlet-mapping>
+      <servlet-name>hello</servlet-name>
+      <url-pattern>/hello/Hello</url-pattern>
+    </servlet-mapping>
+    
+</web-app>

--- a/src/it/compile-with-coverage/verify.groovy
+++ b/src/it/compile-with-coverage/verify.groovy
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+assert new File(basedir, 'target/gwt-coverage.in').exists();
+
+content = new File(basedir, 'target/gwt-coverage.in').text;
+
+// From the project
+assert content.contains( 'org/codehaus/mojo/gwt/test/client/Hello.java' );
+assert content.contains( 'org/codehaus/mojo/gwt/test/client/HelloService.java' );
+assert content.contains( 'org/codehaus/mojo/gwt/test/client/HelloServiceAsync.java' );
+
+// From the dependencies
+assert content.contains( 'com/google/gwt/core/client/GWT.java' );
+
+assert new File(basedir, 'build.log').exists();
+
+content = new File(basedir, 'build.log').text;
+assert content.contains( '-Dgwt.coverage=' );
+assert content.contains( 'target/gwt-coverage.in' );
+
+return true;

--- a/src/main/java/org/codehaus/mojo/gwt/shell/CompileMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/CompileMojo.java
@@ -32,14 +32,21 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.codehaus.mojo.gwt.GwtModule;
 import org.codehaus.mojo.gwt.utils.GwtModuleReaderException;
+import org.codehaus.mojo.gwt.utils.ProjectScanner;
 import org.codehaus.plexus.compiler.util.scan.InclusionScanException;
 import org.codehaus.plexus.compiler.util.scan.StaleSourceScanner;
 import org.codehaus.plexus.compiler.util.scan.mapping.SingleTargetSourceMapping;
 import org.codehaus.plexus.util.StringUtils;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 /**
  * Invokes the GWT Compiler for the project source.
@@ -360,6 +367,12 @@ public class CompileMojo
     @Parameter(defaultValue = "NONE", property = "gwt.compiler.methodNameDisplayMode")
     private String methodNameDisplayMode;
 
+    /**
+     * Code coverage generation configuration.
+     */
+    @Parameter
+    private CoverageConfiguration coverage;
+
     public void doExecute( )
         throws MojoExecutionException, MojoFailureException
     {
@@ -476,6 +489,7 @@ public class CompileMojo
             getLog().debug( "NOT create extra directory " );
         }
 
+        addCoverageArgument( cmd );
         addCompileSourceArtifacts( cmd );
         addArgumentDeploy(cmd);
         addArgumentGen( cmd );
@@ -623,5 +637,63 @@ public class CompileMojo
         {
             throw new MojoExecutionException( e.getMessage(), e );
         }
+    }
+
+    private void addCoverageArgument( JavaCommand cmd )
+        throws MojoExecutionException
+    {
+        if ( coverage != null && coverage.isEnabled() )
+        {
+            SortedSet<String> files = getFilesToCover();
+            if ( files.isEmpty() )
+            {
+                getLog().warn( "Nothing to instrument" );
+            }
+            else
+            {
+                getLog().info( "Will instrument " + files.size() + " files for GWT code coverage" );
+                try
+                {
+                    String buildDirectory = getProject().getBuild().getDirectory();
+                    File outFile = new File( buildDirectory, "gwt-coverage.in" );
+                    PrintStream stream = new PrintStream(outFile);
+                    for ( String file : files )
+                    {
+                        stream.println( file );
+                    }
+                    cmd.systemProperty( "gwt.coverage", outFile.getAbsolutePath() );
+                }
+                catch ( IOException e )
+                {
+                    getLog().warn( "Could not prepare the files for instrumentation", e );
+                }
+            }
+        }
+    }
+
+    private SortedSet<String> getFilesToCover()
+        throws MojoExecutionException
+    {
+        getLog().info( "Building the list of source files to instrument" );
+        getLog().info( "  Includes: " + Arrays.toString(coverage.getIncludes()) );
+        getLog().info( "  Excludes: " + Arrays.toString( coverage.getExcludes() ) );
+        getLog().info( "  Scan dependencies: " + ( coverage.isScanDependencies() ? "yes" : "no" ) );
+
+        ProjectScanner scanner = new ProjectScanner( getLog() );
+        scanner.setProject(getProject());
+        if ( coverage.isScanDependencies() )
+        {
+            scanner.setArtifacts(getClasspath(Artifact.SCOPE_COMPILE));
+        }
+
+        scanner.setIncludes(coverage.getIncludes());
+        scanner.setExcludes(coverage.getExcludes());
+        scanner.scan();
+
+        String[] includedFiles = scanner.getIncludedFiles();
+
+        SortedSet<String> sortedFiles = new TreeSet<String>();
+        Collections.addAll( sortedFiles, includedFiles );
+        return sortedFiles;
     }
 }

--- a/src/main/java/org/codehaus/mojo/gwt/shell/CoverageConfiguration.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/CoverageConfiguration.java
@@ -1,0 +1,51 @@
+package org.codehaus.mojo.gwt.shell;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @author fabien.cortina at gmail.com
+ */
+public final class CoverageConfiguration
+{
+    private boolean enabled = false;
+    private boolean scanDependencies = false;
+    private String[] includes = {};
+    private String[] excludes = {};
+
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    public boolean isScanDependencies()
+    {
+        return scanDependencies;
+    }
+
+    public String[] getIncludes()
+    {
+        return includes;
+    }
+
+    public String[] getExcludes()
+    {
+        return excludes;
+    }
+}

--- a/src/main/java/org/codehaus/mojo/gwt/utils/JarFileScanner.java
+++ b/src/main/java/org/codehaus/mojo/gwt/utils/JarFileScanner.java
@@ -1,0 +1,98 @@
+package org.codehaus.mojo.gwt.utils;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
+
+import org.codehaus.plexus.util.AbstractScanner;
+
+/**
+ * Scans jar files.
+ *
+ * @author fabien.cortina at gmail.com
+ */
+public final class JarFileScanner extends AbstractScanner
+{
+    private final File jarFile;
+    private final Set<String> matchingEntries;
+
+    public JarFileScanner( File jarFile )
+    {
+        this.jarFile = jarFile;
+        this.matchingEntries = new HashSet<String>();
+    }
+
+    public String[] getIncludedFiles()
+    {
+        return matchingEntries.toArray( new String[ matchingEntries.size() ] );
+    }
+
+    public String[] getIncludedDirectories()
+    {
+        return new String[0];
+    }
+
+    public File getBasedir()
+    {
+        return null;
+    }
+
+    public void scan()
+    {
+        matchingEntries.clear();
+
+        try
+        {
+            scanJarFileEntries();
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( "Error scanning file " + jarFile, e );
+        }
+    }
+
+    private void scanJarFileEntries()
+        throws IOException
+    {
+        InputStream fileInputStream = new FileInputStream( jarFile );
+        InputStream bufferedInputStream = new BufferedInputStream( fileInputStream );
+        JarInputStream jarInputStream = new JarInputStream( bufferedInputStream );
+
+        JarEntry jarEntry;
+        while ( ( jarEntry = jarInputStream.getNextJarEntry() ) != null )
+        {
+            String entryName = jarEntry.getName();
+            if ( isIncluded( entryName ) )
+            {
+                if ( !isExcluded( entryName ) )
+                {
+                    matchingEntries.add(entryName);
+                }
+            }
+            jarInputStream.closeEntry();
+        }
+
+        jarInputStream.close();
+    }
+}

--- a/src/main/java/org/codehaus/mojo/gwt/utils/JarFileScanner.java
+++ b/src/main/java/org/codehaus/mojo/gwt/utils/JarFileScanner.java
@@ -64,6 +64,9 @@ public final class JarFileScanner extends AbstractScanner
 
         try
         {
+            setupDefaultFilters();
+            setupMatchPatterns();
+
             scanJarFileEntries();
         }
         catch ( IOException e )

--- a/src/main/java/org/codehaus/mojo/gwt/utils/ProjectScanner.java
+++ b/src/main/java/org/codehaus/mojo/gwt/utils/ProjectScanner.java
@@ -1,0 +1,166 @@
+package org.codehaus.mojo.gwt.utils;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+import java.util.*;
+
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.AbstractScanner;
+import org.codehaus.plexus.util.DirectoryScanner;
+
+/**
+ * Scans a project and/or artifacts.
+ *
+ * @author fabien.cortina at gmail.com
+ */
+public final class ProjectScanner extends AbstractScanner
+{
+    private final Log log;
+    private final SortedSet<String> matchingFiles;
+
+    private MavenProject project;
+    private Collection<File> artifacts;
+
+    public ProjectScanner( Log log )
+    {
+        this.log = log;
+        this.matchingFiles = new TreeSet<String>();
+    }
+
+    public MavenProject getProject()
+    {
+        return project;
+    }
+
+    public void setProject( MavenProject project )
+    {
+        this.project = project;
+    }
+
+    public Collection<File> getArtifacts()
+    {
+        return artifacts == null ? Collections.<File>emptyList() : artifacts;
+    }
+
+    public void setArtifacts( Collection<File> artifacts )
+    {
+        this.artifacts = artifacts;
+    }
+
+    public String[] getIncludedFiles()
+    {
+        return matchingFiles.toArray( new String[ matchingFiles.size() ] );
+    }
+
+    public String[] getIncludedDirectories()
+    {
+        return new String[0];
+    }
+
+    public File getBasedir()
+    {
+        return project.getBasedir();
+    }
+
+    public void scan()
+    {
+        matchingFiles.clear();
+
+        for ( File root : getSourceRoots() )
+        {
+            scan( root );
+        }
+
+        for ( File artifact : getArtifacts() )
+        {
+            scan( artifact );
+        }
+    }
+
+    private Collection<File> getSourceRoots()
+    {
+        Collection<File> directories = new LinkedList<File>();
+        if ( project != null )
+        {
+            @SuppressWarnings("unchecked")
+            Collection<String> roots = (Collection<String>) project.getCompileSourceRoots();
+            for ( String root : roots )
+            {
+                File directory = new File( root );
+                directories.add( directory );
+            }
+        }
+        return directories;
+    }
+
+    private void scan( File fileOrDirectory )
+    {
+        try
+        {
+            if ( log.isDebugEnabled() )
+            {
+                log.debug( "Scanning: " + fileOrDirectory.getPath() );
+            }
+
+            AbstractScanner scanner = scannerFor( fileOrDirectory );
+            scanner.setIncludes( includes );
+            scanner.setExcludes( excludes );
+            scanner.scan();
+
+            Collections.addAll( matchingFiles, scanner.getIncludedFiles() );
+        }
+        catch ( FileNotFoundException e )
+        {
+            log.warn( e.getMessage() );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            log.warn( e.getMessage() );
+        }
+        catch ( Throwable t )
+        {
+            log.warn( "Error while scanning '" + fileOrDirectory.getPath() + "'", t );
+        }
+    }
+
+    private AbstractScanner scannerFor( File fileOrDirectory )
+            throws FileNotFoundException, IllegalArgumentException {
+        if ( !fileOrDirectory.exists() )
+        {
+            throw new FileNotFoundException( "File does not exist: " + fileOrDirectory );
+        }
+        else if ( fileOrDirectory.isDirectory() )
+        {
+            DirectoryScanner scanner = new DirectoryScanner();
+            scanner.setBasedir( fileOrDirectory );
+            return scanner;
+        }
+        else if ( fileOrDirectory.getName().endsWith( ".jar") )
+        {
+            return new JarFileScanner( fileOrDirectory );
+        }
+        else
+        {
+            throw new IllegalArgumentException( "Unexpected file: " + fileOrDirectory );
+        }
+    }
+}


### PR DESCRIPTION
I want to generate code coverage reports for a GWT project. The GWT compiler can be passed a list of files it will instrument, but this is not convenient in my case. I'd rather be able to give a list of patterns and turn on/off instrumentation using maven profiles.

Typical usage:

    <plugin>
        <groupId>org.codehaus.mojo</groupId>
        <artifactId>gwt-maven-plugin</artifactId>
        <configuration>
            <coverage>
                <enabled>true</enabled>
                <scanDependencies>false</scanDependencies>
                <includes>
                    <include>com/myproject/client/**/*.java</include>
                </includes>
                <excludes>
                    <exclude>**/notneeded/**</exclude>
                </excludes>
            </coverage>
        </configuration>
    </plugin>

Please note that I'm rather new to Maven plugins so this may not be perfect (although it works nicely for me).