### PR TITLE
Removed standards mode flag to correctly work with GWT 2.7 snapshots

### DIFF
--- a/src/main/java/org/codehaus/mojo/gwt/shell/TestMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/TestMojo.java
@@ -181,14 +181,6 @@ public class TestMojo
     private File reportsDirectory;
     
     /**
-     * Run each test using an HTML document in quirks mode (rather than standards mode)
-     * 
-     * @parameter default-value="false"
-     * @since 2.5.0-rc1
-     */
-    private boolean quirksMode;
-    
-    /**
      * Specify the user agents to reduce the number of permutations in '-prod' mode;
      * e.g. ie6,ie8,safari,gecko1_8,opera
      * 
@@ -492,7 +484,6 @@ public class TestMojo
         sb.append( inlineLiteralParameters ? " -XinlineLiteralParameters" : " -XnoinlineLiteralParameters" );
         sb.append( optimizeDataflow ? " -XoptimizeDataflow" : " -XnooptimizeDataflow" );
         sb.append( ordinalizeEnums ? " -XordinalizeEnums" : " -XnoordinalizeEnums" );
-        sb.append( quirksMode ? " -norunStandardsMode" : " -runStandardsMode" );
         sb.append( removeDuplicateFunctions ? " -XremoveDuplicateFunctions" : " -XnoremoveDuplicateFunctions" );
         sb.append( showUi ? " -showUi" : " -noshowUi" );
         sb.append( " -sourceLevel " ).append( quote( sourceLevel ) );


### PR DESCRIPTION
Is there a cleaner way to set this up so that we can merely skip it? Say, instead of "-runStandardsMode", just skip the sb.append? I'm open to suggestions.
