### PR TITLE
Add support for modulePathPrefix in gwt:run

### DIFF
--- a/src/main/java/org/codehaus/mojo/gwt/AbstractGwtMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/AbstractGwtMojo.java
@@ -50,6 +50,7 @@ import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.StringUtils;
 
 /**
  * Abstract Support class for all GWT-related operations.
@@ -141,6 +142,15 @@ public abstract class AbstractGwtMojo
     private File webappDirectory;
 
     /**
+     * Prefix to prepend to module names inside {@code webappDirectory} or in URLs in DevMode.
+     * <p>
+     * Could also be seen as a suffix to {@code webappDirectory}.
+     * 
+     * @parameter expression="${gwt.modulePathPrefix}"
+     */
+    protected String modulePathPrefix;
+
+    /**
      * Location of the web application static resources (same as maven-war-plugin parameter)
      *
      * @parameter default-value="${basedir}/src/main/webapp"
@@ -167,7 +177,12 @@ public abstract class AbstractGwtMojo
 
     public File getOutputDirectory()
     {
-        return inplace ? warSourceDirectory : webappDirectory;
+        File out = inplace ? warSourceDirectory : webappDirectory;
+        if ( !StringUtils.isBlank( modulePathPrefix ) ) 
+        {
+            out = new File(out, modulePathPrefix);
+        }
+        return out;
     }
 
     /**

--- a/src/main/java/org/codehaus/mojo/gwt/shell/RunMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/RunMojo.java
@@ -421,6 +421,11 @@ public class RunMojo
             cmd.arg( "-bindAddress" ).arg( bindAddress );
         }
 
+        if ( modulePathPrefix != null && !modulePathPrefix.isEmpty() )
+        {
+            cmd.arg( "-modulePathPrefix" ).arg( modulePathPrefix );
+        }
+
         if ( !noServer )
         {
             setupExplodedWar();


### PR DESCRIPTION
Automatically suffix webappDirectory with the provided modulePathPrefix
so gwt:compile outputs the modules to the same directory (provided
webappDirectory and hostedWebapp have the same value).

Proposed fix for #92
