### PR TITLE
Add gwt-compile config option 'printJavaCommandOnError'

### DIFF
--- a/src/main/java/org/codehaus/mojo/gwt/shell/CompileMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/CompileMojo.java
@@ -359,6 +359,16 @@ public class CompileMojo
     @Parameter(defaultValue = "NONE", property = "gwt.compiler.methodNameDisplayMode")
     private String methodNameDisplayMode;
 
+    /**
+     * Indicates whether to print the whole Java command used for GWT compilation, in case of an error. If set to false,
+     * the command is not printed.
+     *
+     * Ability to disable the command comes handy in case the build uses big number (hundreds) of jars. In that case the
+     * classpath string is huge and the printed command is polluting the Maven build log.
+     */
+    @Parameter(defaultValue = "true", property = "gwt.compiler.printJavaCommandOnError" )
+    private boolean printJavaCommandOnError;
+
     public void doExecute( )
         throws MojoExecutionException, MojoFailureException
     {
@@ -494,6 +504,9 @@ public class CompileMojo
             cmd.arg( target );
             upToDate = false;
         }
+
+        cmd.setPrintCommandOnError(printJavaCommandOnError);
+
         if ( !upToDate )
         {
             try

--- a/src/main/java/org/codehaus/mojo/gwt/shell/JavaCommand.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/JavaCommand.java
@@ -84,6 +84,11 @@ public class JavaCommand
         }
     };
 
+    /**
+     * Indicates whether to print the full command (as part of exception message) when encountering error.
+     */
+    private boolean printCommandOnError = true;
+
     public String getMainClass()
     {
         return mainClass;
@@ -210,6 +215,10 @@ public class JavaCommand
         return this;
     }
 
+    public void setPrintCommandOnError( boolean printCommandOnError ) {
+        this.printCommandOnError = printCommandOnError;
+    }
+
     public JavaCommand addToClasspath( File file )
     {
         return addToClasspath( Collections.singleton( file ) );
@@ -324,8 +333,9 @@ public class JavaCommand
 
             if ( status != 0 )
             {
-                throw new JavaCommandException( "Command [[\n" + cmd.toString()
-                    + "\n]] failed with status " + status );
+                throw new JavaCommandException( "Command "
+                        + ( printCommandOnError ? "[[\n" + cmd.toString() + "\n]] " : "" )
+                        + "failed with status "  + status );
             }
         }
         catch ( CommandLineTimeOutException e )
@@ -335,11 +345,13 @@ public class JavaCommand
                 log.warn( "Forked JVM has been killed on time-out after " + timeOut + " seconds" );
                 return;
             }
-            throw new JavaCommandException( "Time-out on command line execution :\n" + command, e );
+            throw new JavaCommandException(
+                    "Time-out on command line execution" + (printCommandOnError ? ":\n" + command : ""), e );
         }
         catch ( CommandLineException e )
         {
-            throw new JavaCommandException( "Failed to execute command line :\n" + command, e );
+            throw new JavaCommandException(
+                    "Failed to execute command line" + (printCommandOnError ? ":\n" + command : ""), e );
         }
     }
 
@@ -357,7 +369,7 @@ public class JavaCommand
         if ( !jvmFile.exists() )
         {
             throw new JavaCommandException( "the configured jvm " + jvm
-                + " doesn't exists please check your environnement" );
+                + " doesn't exists please check your environment" );
         }
         if ( jvmFile.isDirectory() )
         {

--- a/src/test/java/org/codehaus/mojo/gwt/shell/JavaCommandTest.java
+++ b/src/test/java/org/codehaus/mojo/gwt/shell/JavaCommandTest.java
@@ -1,0 +1,58 @@
+package org.codehaus.mojo.gwt.shell;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.plugin.testing.SilentLog;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JavaCommandTest {
+
+    @Test
+    public void testExceptionMessageContainsCommandByDefault() {
+        JavaCommand javaCommand = new JavaCommand();
+        javaCommand.setLog( new SilentLog() );
+        javaCommand.setMainClass( "MyMainClass" );
+
+        try {
+            javaCommand.execute();
+            Assert.fail( "Expecting JavaCommandException to be thrown!" );
+        } catch ( JavaCommandException e ) {
+            // the exception message should contain the command and thus the configured main class name
+            Assert.assertTrue( "Exception message did not contain expected main class", e.getMessage().contains( "MyMainClass" ) );
+        }
+    }
+
+    @Test
+    public void testExceptionMessageDoesNotContainCommandWhenConfigured() {
+        JavaCommand javaCommand = new JavaCommand();
+        javaCommand.setLog( new SilentLog() );
+        javaCommand.setMainClass( "MyMainClass" );
+        javaCommand.setPrintCommandOnError( false );
+
+        try {
+            javaCommand.execute();
+            Assert.fail( "Expecting JavaCommandException to be thrown!" );
+        } catch ( JavaCommandException e ) {
+            // the exception message should _not_ contain the command and thus _not_ the main class name
+            Assert.assertFalse( "Exception message did contain expected main class", e.getMessage().contains( "MyMainClass" ) );
+        }
+    }
+}


### PR DESCRIPTION
 * the option is true by default, to keep the default
   behavior unchanged

 * setting it to false results in error messages which
   do _not_ contain the Java command used (very useful
   when the command is huge and pollutes the build log)

Please let me know if this something that you would consider adding into the plugin. Thanks for looking into this!

CC @csadilek