### PR TITLE
Issue #136: Do not add GWT libs (user or dev) if the lib is already a project dependency

### DIFF
--- a/src/main/java/org/codehaus/mojo/gwt/eclipse/EclipseMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/eclipse/EclipseMojo.java
@@ -272,7 +272,7 @@ public class EclipseMojo
             context.put( "project", eclipseUtil.getProjectName( getProject() ) );
 
             Collection<String> gwtDevJarPath = new ArrayList<String>();
-            for (File f : getGwtDevJar())
+            for (File f : getJarFiles(GWT_DEV, false))
             {
                 gwtDevJarPath.add( f.getAbsolutePath().replace( '\\', '/' ) );
             }

--- a/src/main/java/org/codehaus/mojo/gwt/eclipse/EclipseTestMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/eclipse/EclipseTestMojo.java
@@ -129,7 +129,7 @@ public class EclipseTestMojo
         try
         {
             Collection<String> gwtDevJarPath = new ArrayList<String>();
-            for (File f : getGwtDevJar())
+            for (File f : getJarFiles(GWT_DEV, false))
             {
                 gwtDevJarPath.add( f.getAbsolutePath().replace( '\\', '/' ) );
             }

--- a/src/main/java/org/codehaus/mojo/gwt/shell/CSSMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/CSSMojo.java
@@ -116,8 +116,8 @@ public class CSSMojo
                                 .arg( typeName )
                                 .arg( "-css" )
                                 .arg( candidate.getAbsolutePath() )
-                                .addToClasspath( getGwtDevJar() )
-                                .addToClasspath( getGwtUserJar() )
+                                .addToClasspath( getJarFiles(GWT_DEV, false) )
+                                .addToClasspath( getJarFiles(GWT_USER, false) )
                                 .setOut( new StreamConsumer()
                                     {
                                         public void consumeLine( String line )


### PR DESCRIPTION
This PR changes the behaviour of the plugin so that dependencies excluded in the plugin and plugin management of the gwt-maven-plugin are not added to the classpath.