### PR TITLE
Force task to throw an exception if process is killed on timeout.

### DIFF
--- a/src/main/java/org/codehaus/mojo/gwt/shell/JavaCommand.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/JavaCommand.java
@@ -333,10 +333,6 @@ public class JavaCommand
         }
         catch ( CommandLineTimeOutException e )
         {
-            if ( timeOut > 0 )
-            {
-                log.error( "Forked JVM has been killed on time-out after " + timeOut + " seconds" );
-            }
             throw new JavaCommandException(
                     "Time-out on command line execution" + (printCommandOnError ? ":\n" + command : ""), e );
         }

--- a/src/main/java/org/codehaus/mojo/gwt/shell/JavaCommand.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/JavaCommand.java
@@ -335,8 +335,7 @@ public class JavaCommand
         {
             if ( timeOut > 0 )
             {
-                log.warn( "Forked JVM has been killed on time-out after " + timeOut + " seconds" );
-                return;
+                log.error( "Forked JVM has been killed on time-out after " + timeOut + " seconds" );
             }
             throw new JavaCommandException(
                     "Time-out on command line execution" + (printCommandOnError ? ":\n" + command : ""), e );


### PR DESCRIPTION
Hello.

I would like to submit a PR that makes plugin to throw `JavaCommandException` in case if timeout during task execution was exceeded.

The reason for this change is to prevent tests results being neglected on timeout: current implementation simply kills the process and mvn execution carries on, neither showing test results, nor considering any of them as failed (even if there were some).

In my opinion, this behavior is very error prone, since CI builds can look like passing ones, even though there are timeouts and failures in gwt tests.

The patch is very small and seems like it does not break any tests (`mvn verify` successfully passed).
Can you please review it and give you feedback?