### PR TITLE
In Google Web Toolkit 2.8.0 the source level must be one of [auto, 1.8]

### DIFF
--- a/generated-archetype/some-artifact/pom.xml
+++ b/generated-archetype/some-artifact/pom.xml
@@ -15,9 +15,9 @@
     <!-- Convenience property to set the GWT version -->
     <gwtVersion>2.8.0-SNAPSHOT</gwtVersion>
 
-    <!-- GWT needs at least java 1.7 -->
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <!-- GWT needs at least java 1.8 -->
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>


### PR DESCRIPTION
Fixes this error message:
[INFO] --- gwt-maven-plugin:2.8.0:compile (default) @ myartifact ---
[ERROR] Source level must be one of [auto, 1.8].
[ERROR] Google Web Toolkit 2.8.0