### PR TITLE
#161 Support the setProperty option from the GWT compiler 

### DIFF
--- a/src/it/compile/pom.xml
+++ b/src/it/compile/pom.xml
@@ -69,6 +69,10 @@
             -Xms64m
             -Xmx1g
           </extraJvmArgs>
+          <compilerArgs>
+            <arg>-setProperty</arg>
+            <arg>user.agent=gecko1_8</arg>
+          </compilerArgs>
         </configuration>
         <executions>
           <execution>

--- a/src/it/compile/src/main/java/com/google/gwt/sample/hello/Hello.gwt.xml
+++ b/src/it/compile/src/main/java/com/google/gwt/sample/hello/Hello.gwt.xml
@@ -17,5 +17,5 @@
   <source path="client"/>
   <public path="public"/>
   <entry-point class="com.google.gwt.sample.hello.client.Hello"/>
-  <set-property name="user.agent" value="gecko1_8"/>  
+  <set-property name="user.agent" value="safari"/>  
 </module>

--- a/src/it/compile/src/main/java/org/codehaus/mojo/gwt/test/Hello.gwt.xml
+++ b/src/it/compile/src/main/java/org/codehaus/mojo/gwt/test/Hello.gwt.xml
@@ -25,5 +25,5 @@
   <public path="public"/>
   <entry-point class="org.codehaus.mojo.gwt.test.client.Hello"/>
   <servlet path="/HelloService" class="org.codehaus.mojo.gwt.test.server.HelloRemoteServlet"/>
-  <set-property name="user.agent" value="gecko1_8"/>  
+  <set-property name="user.agent" value="safari"/>  
 </module>

--- a/src/it/compile/verify.groovy
+++ b/src/it/compile/verify.groovy
@@ -51,5 +51,6 @@ assert content.contains( '-XnoremoveDuplicateFunctions' );
 assert content.contains( "'-sourceLevel' 'auto'" ) || content.contains( "-sourceLevel auto" );
 assert content.contains( "'-Xnamespace' 'NONE'" ) || content.contains( "-Xnamespace NONE" );
 assert content.contains( "'-XmethodNameDisplayMode' 'FULL'" ) || content.contains( "-XmethodNameDisplayMode FULL" );
+assert content.contains( '-setProperty user.agent=gecko1_8' );
   
 return true;

--- a/src/main/java/org/codehaus/mojo/gwt/shell/CompileMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/CompileMojo.java
@@ -23,6 +23,7 @@ package org.codehaus.mojo.gwt.shell;
  *
  */
 
+import java.util.List;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -370,6 +371,14 @@ public class CompileMojo
     @Parameter(defaultValue = "true", property = "gwt.compiler.printJavaCommandOnError" )
     private boolean printJavaCommandOnError;
 
+    /**
+     * Additional arguments to be passed to the GWT compiler.
+     *
+     * @since 2.9.1 (since 2.7.0 of GWT compiler) 
+     */
+    @Parameter
+    private List<String> compilerArgs;
+
     public void doExecute( )
         throws MojoExecutionException, MojoFailureException
     {
@@ -495,6 +504,13 @@ public class CompileMojo
         if ( workDir != null )
         {
             cmd.arg( "-workDir" ).arg( String.valueOf( workDir ) );
+        }
+        
+        if (compilerArgs != null) {
+            for (String compilerArg : compilerArgs) 
+            {
+                cmd.arg(compilerArg);
+            }
         }
 
         for ( String target : modules )


### PR DESCRIPTION
- introduce generic compilerArgs-option to set options like setProperty

Adapted from the new plugin https://github.com/tbroyer/gwt-maven-plugin/blob/main/src/main/java/net/ltgt/gwt/maven/CompileMojo.java#L122

Based on command line options from
http://www.gwtproject.org/doc/latest/DevGuideCompilingAndDebugging.html#DevGuideCompilerOptions
  -setProperty                                      Set the values of a property in the form of propertyName=value1[,value2...].