### PR TITLE
Update to GWT 2.10, with the changed groupId and htmlunit browsers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <!-- This property is used in a filtered resources to check the version compatibility -->
-    <gwt.version>2.9.0</gwt.version>
+    <gwt.version>2.10.0</gwt.version>
     <mavenVersion>3.0.5</mavenVersion>
     <mavenPluginPluginVersion>3.5</mavenPluginPluginVersion>
     <mojo.java.target>1.8</mojo.java.target>
@@ -233,12 +233,12 @@
       <version>2.3.20</version>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-dev</artifactId>
       <version>${gwt.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>${gwt.version}</version>
     </dependency>
@@ -366,10 +366,10 @@
               <settingsFile>src/it/settings.xml</settingsFile>
               <cloneProjectsTo>${project.build.directory}/it-tests</cloneProjectsTo>
               <extraArtifacts>
-                <extraArtifact>com.google.gwt:gwt-servlet:${gwt.version}:jar</extraArtifact>
-                <!-- for some reason, com.google.web.bindery:requestfactory isn't installed,
-                     whereas it's needed by com.google.gwt:gwt -->
-                <extraArtifact>com.google.web.bindery:requestfactory:${gwt.version}:pom</extraArtifact>
+                <extraArtifact>org.gwtproject:gwt-servlet:${gwt.version}:jar</extraArtifact>
+                <!-- for some reason, org.gwtproject.web.bindery:requestfactory isn't installed,
+                     whereas it's needed by org.gwtproject.gwt:gwt -->
+                <extraArtifact>org.gwtproject.web.bindery:requestfactory:${gwt.version}:pom</extraArtifact>
               </extraArtifacts>
             </configuration>
             <executions>

--- a/src/it/MGWT-226/gwt/pom.xml
+++ b/src/it/MGWT-226/gwt/pom.xml
@@ -16,11 +16,11 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-servlet</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
     </dependency>
     <dependency>

--- a/src/it/MGWT-226/pom.xml
+++ b/src/it/MGWT-226/pom.xml
@@ -36,12 +36,12 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.google.gwt</groupId>
+        <groupId>org.gwtproject</groupId>
         <artifactId>gwt-servlet</artifactId>
         <version>@gwt.version@</version>
       </dependency>
       <dependency>
-        <groupId>com.google.gwt</groupId>
+        <groupId>org.gwtproject</groupId>
         <artifactId>gwt-user</artifactId>
         <version>@gwt.version@</version>
       </dependency>

--- a/src/it/MGWT-226/rpc1/pom.xml
+++ b/src/it/MGWT-226/rpc1/pom.xml
@@ -14,12 +14,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-servlet</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/src/it/MGWT-226/rpc2/pom.xml
+++ b/src/it/MGWT-226/rpc2/pom.xml
@@ -14,12 +14,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-servlet</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/src/it/MGWT-290/pom.xml
+++ b/src/it/MGWT-290/pom.xml
@@ -94,7 +94,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
     </dependency>

--- a/src/it/MGWT-315-generateasync-with-compiled-classes/pom.xml
+++ b/src/it/MGWT-315-generateasync-with-compiled-classes/pom.xml
@@ -59,7 +59,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
       <scope>provided</scope>

--- a/src/it/MGWT-352/pom.xml
+++ b/src/it/MGWT-352/pom.xml
@@ -65,7 +65,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
       <scope>provided</scope>

--- a/src/it/MGWT-372/pom.xml
+++ b/src/it/MGWT-372/pom.xml
@@ -56,7 +56,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
       <scope>provided</scope>

--- a/src/it/async-with-inner-class/pom.xml
+++ b/src/it/async-with-inner-class/pom.xml
@@ -65,7 +65,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
       <scope>provided</scope>

--- a/src/it/compile-gwt-sdk-first/pom.xml
+++ b/src/it/compile-gwt-sdk-first/pom.xml
@@ -64,7 +64,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
     </dependency>

--- a/src/it/compile-report/pom.xml
+++ b/src/it/compile-report/pom.xml
@@ -95,7 +95,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
     </dependency>

--- a/src/it/compile/pom.xml
+++ b/src/it/compile/pom.xml
@@ -84,7 +84,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
     </dependency>

--- a/src/it/css-mojo/pom.xml
+++ b/src/it/css-mojo/pom.xml
@@ -66,7 +66,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
     </dependency>

--- a/src/it/gwt-test-fail/pom.xml
+++ b/src/it/gwt-test-fail/pom.xml
@@ -61,13 +61,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-servlet</artifactId>
       <version>@gwt.version@</version>
       <scope>compile</scope>

--- a/src/it/i18n-creator/pom.xml
+++ b/src/it/i18n-creator/pom.xml
@@ -69,7 +69,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
     </dependency>

--- a/src/it/indirect-remote-service/pom.xml
+++ b/src/it/indirect-remote-service/pom.xml
@@ -55,7 +55,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
       <scope>provided</scope>

--- a/src/it/inherited-modules/pom.xml
+++ b/src/it/inherited-modules/pom.xml
@@ -80,7 +80,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
     </dependency>

--- a/src/it/mergewebxmlmojo/pom.xml
+++ b/src/it/mergewebxmlmojo/pom.xml
@@ -79,7 +79,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
     </dependency>

--- a/src/it/mergewebxmlmojoannotation/pom.xml
+++ b/src/it/mergewebxmlmojoannotation/pom.xml
@@ -75,7 +75,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
     </dependency>

--- a/src/it/mergewebxmlmojopathasis/pom.xml
+++ b/src/it/mergewebxmlmojopathasis/pom.xml
@@ -80,7 +80,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
     </dependency>

--- a/src/it/mgwt-186/pom.xml
+++ b/src/it/mgwt-186/pom.xml
@@ -56,7 +56,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
       <scope>provided</scope>

--- a/src/it/reactor/pom.xml
+++ b/src/it/reactor/pom.xml
@@ -56,13 +56,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.google.gwt</groupId>
+        <groupId>org.gwtproject</groupId>
         <artifactId>gwt-user</artifactId>
         <version>@gwt.version@</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>com.google.gwt</groupId>
+        <groupId>org.gwtproject</groupId>
         <artifactId>gwt-servlet</artifactId>
         <version>@gwt.version@</version>
         <scope>runtime</scope>

--- a/src/it/reactor/war/pom.xml
+++ b/src/it/reactor/war/pom.xml
@@ -34,12 +34,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-servlet</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/src/it/resources-mojo/pom.xml
+++ b/src/it/resources-mojo/pom.xml
@@ -64,7 +64,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
     </dependency>

--- a/src/main/archetype/archetype-resources/pom.xml
+++ b/src/main/archetype/archetype-resources/pom.xml
@@ -25,7 +25,7 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.google.gwt</groupId>
+        <groupId>org.gwtproject</groupId>
         <artifactId>gwt</artifactId>
         <version>\${gwt.version}</version>
         <type>pom</type>
@@ -36,17 +36,17 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-servlet</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-dev</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/src/main/java/org/codehaus/mojo/gwt/AbstractGwtMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/AbstractGwtMojo.java
@@ -71,12 +71,12 @@ import java.util.Set;
 public abstract class AbstractGwtMojo
     extends AbstractMojo
 {
-    protected static final String GWT_USER = "com.google.gwt:gwt-user";
+    protected static final String GWT_USER = "org.gwtproject:gwt-user";
 
-    protected static final String GWT_DEV = "com.google.gwt:gwt-dev";
+    protected static final String GWT_DEV = "org.gwtproject:gwt-dev";
 
     /** GWT artifacts groupId */
-    public static final String GWT_GROUP_ID = "com.google.gwt";
+    public static final String GWT_GROUP_ID = "org.gwtproject";
 
     // --- Some Maven tools ----------------------------------------------------
 
@@ -287,7 +287,7 @@ public abstract class AbstractGwtMojo
             result = resolver.resolveTransitively( dependencyArtifacts, rootArtifact,
                                                    Collections.EMPTY_MAP, localRepository,
                                                    remoteRepositories, artifactMetadataSource,
-                                                   null, Collections.EMPTY_LIST);
+                                                   null, Collections.emptyList());
         }
         catch (Exception e)
         {

--- a/src/main/java/org/codehaus/mojo/gwt/shell/TestMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/TestMojo.java
@@ -109,11 +109,11 @@ public class TestMojo
 
     /**
      * Configure options to run tests with HTMLUnit. The value must describe the browser emulation
-     * to be used, FF31, FF38, IE8, IE11, Chrome or Edge (possible multiple values separated by comas).
+     * to be used, FF, Chrome, IE or Edge (possible multiple values separated by commas).
      * 
      * @see http://code.google.com/intl/fr/webtoolkit/doc/latest/DevGuideTestingHtmlUnit.html
      */
-    @Parameter(defaultValue = "FF38", property = "gwt.test.htmlunit")
+    @Parameter(defaultValue = "FF", property = "gwt.test.htmlunit")
     private String htmlunit;
 
     /**

--- a/src/site/apt/eclipse/google_plugin.apt.vm
+++ b/src/site/apt/eclipse/google_plugin.apt.vm
@@ -71,12 +71,12 @@ Using the Google Eclipse Plugin
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-servlet</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/src/site/apt/user-guide/project.apt.vm
+++ b/src/site/apt/user-guide/project.apt.vm
@@ -32,13 +32,13 @@ Project organization
 +--
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-servlet</artifactId>
       <version>${sitePluginVersion}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>${sitePluginVersion}</version>
       <scope>provided</scope>

--- a/src/site/apt/user-guide/setup.apt
+++ b/src/site/apt/user-guide/setup.apt
@@ -17,13 +17,13 @@ Setup Maven for GWT development
 +--
   <dependencies>
 	  <dependency>
-	    <groupId>com.google.gwt</groupId>
+	    <groupId>org.gwtproject</groupId>
 	    <artifactId>gwt-servlet</artifactId>
 	    <version>${sitePluginVersion}</version>
 	    <scope>compile</scope>
 	  </dependency>
 	  <dependency>
-	    <groupId>com.google.gwt</groupId>
+	    <groupId>org.gwtproject</groupId>
 	    <artifactId>gwt-user</artifactId>
 	    <version>${sitePluginVersion}</version>
 	    <scope>provided</scope>

--- a/src/site/apt/user-guide/using-different-gwt-sdk-version.apt.vm
+++ b/src/site/apt/user-guide/using-different-gwt-sdk-version.apt.vm
@@ -49,17 +49,17 @@ Using a different GWT SDK version
         <version>${sitePluginVersion}</version>
         <dependencies>
           <dependency>
-            <groupId>com.google.gwt</groupId>
+            <groupId>org.gwtproject</groupId>
             <artifactId>gwt-user</artifactId>
             <version>${siteGwtVersion}</version>
           </dependency>
           <dependency>
-            <groupId>com.google.gwt</groupId>
+            <groupId>org.gwtproject</groupId>
             <artifactId>gwt-dev</artifactId>
             <version>${siteGwtVersion}</version>
           </dependency>
           <dependency>
-            <groupId>com.google.gwt</groupId>
+            <groupId>org.gwtproject</groupId>
             <artifactId>gwt-codeserver</artifactId>
             <version>${siteGwtVersion}</version>
           </dependency>


### PR DESCRIPTION
This won't build (and probably shouldn't merge) until the new release is available.