### PR TITLE
use File.separator in test to remain platform-agnostic

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+This is a friendly fork of the original project at
+
+  https://github.com/gwt-maven-plugin/gwt-maven-plugin
+
+We assume that the general contribution guidelines of the GWT project, as can be found, e.g., at
+
+  http://www.gwtproject.org/makinggwtbetter.html
+
+apply. In addition, please adhere to
+
+  https://github.com/SAP/.github/blob/main/CONTRIBUTING_USING_GENAI.md

--- a/src/it/compile-with-coverage/verify.groovy
+++ b/src/it/compile-with-coverage/verify.groovy
@@ -21,17 +21,17 @@ assert new File(basedir, 'target/gwt-coverage.in').exists();
 content = new File(basedir, 'target/gwt-coverage.in').text;
 
 // From the project
-assert content.contains( 'org/codehaus/mojo/gwt/test/client/Hello.java' );
-assert content.contains( 'org/codehaus/mojo/gwt/test/client/HelloService.java' );
-assert content.contains( 'org/codehaus/mojo/gwt/test/client/HelloServiceAsync.java' );
+assert content.contains( 'org' + File.separator + 'codehaus' + File.separator + 'mojo' + File.separator + 'gwt' + File.separator + 'test' + File.separator + 'client' + File.separator + 'Hello.java' );
+assert content.contains( 'org' + File.separator + 'codehaus' + File.separator + 'mojo' + File.separator + 'gwt' + File.separator + 'test' + File.separator + 'client' + File.separator + 'HelloService.java' );
+assert content.contains( 'org' + File.separator + 'codehaus' + File.separator + 'mojo' + File.separator + 'gwt' + File.separator + 'test' + File.separator + 'client' + File.separator + 'HelloServiceAsync.java' );
 
 // From the dependencies
-assert content.contains( 'com/google/gwt/core/client/GWT.java' );
+assert content.contains( 'com' + File.separator + 'google' + File.separator + 'gwt' + File.separator + 'core' + File.separator + 'client' + File.separator + 'GWT.java' );
 
 assert new File(basedir, 'build.log').exists();
 
 content = new File(basedir, 'build.log').text;
 assert content.contains( '-Dgwt.coverage=' );
-assert content.contains( 'target/gwt-coverage.in' );
+assert content.contains( 'target' + File.separator + 'gwt-coverage.in' );
 
 return true;

--- a/src/main/java/org/codehaus/mojo/gwt/shell/TestMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/TestMojo.java
@@ -128,7 +128,7 @@ public class TestMojo
     /**
      * Time out (in seconds) for test execution in dedicated JVM
      */
-    @Parameter(defaultValue = "60")
+    @Parameter(defaultValue = "600")
     @SuppressWarnings("unused")
     private int testTimeOut;
 

--- a/src/main/java/org/codehaus/mojo/gwt/utils/JarFileScanner.java
+++ b/src/main/java/org/codehaus/mojo/gwt/utils/JarFileScanner.java
@@ -1,5 +1,8 @@
 package org.codehaus.mojo.gwt.utils;
 
+import org.apache.commons.logging.Log;
+import org.codehaus.plexus.util.AbstractScanner;
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -18,14 +21,17 @@ package org.codehaus.mojo.gwt.utils;
  * specific language governing permissions and limitations
  * under the License.
  */
-
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
 
-import org.codehaus.plexus.util.AbstractScanner;
+import cern.colt.Arrays;
 
 /**
  * Scans jar files.
@@ -36,11 +42,13 @@ public final class JarFileScanner extends AbstractScanner
 {
     private final File jarFile;
     private final Set<String> matchingEntries;
+    private final Log log;
 
-    public JarFileScanner( File jarFile )
+    public JarFileScanner( File jarFile, Log log )
     {
         this.jarFile = jarFile;
         this.matchingEntries = new HashSet<String>();
+        this.log = log;
     }
 
     public String[] getIncludedFiles()
@@ -91,6 +99,22 @@ public final class JarFileScanner extends AbstractScanner
                 if ( !isExcluded( entryName ) )
                 {
                     matchingEntries.add(entryName);
+                }
+                else
+                {
+                    if (log.isDebugEnabled())
+                    {
+                        log.debug("entry " + entryName + " rejected; includes: " + Arrays.toString(
+                            includes) + "; excludes: " + Arrays.toString(excludes));
+                    }
+                }
+            }
+            else
+            {
+                if (log.isDebugEnabled())
+                {
+                    log.debug("entry " + entryName + " rejected; includes: " + Arrays.toString(
+                        includes) + "; excludes: " + Arrays.toString(excludes));
                 }
             }
             jarInputStream.closeEntry();

--- a/src/main/java/org/codehaus/mojo/gwt/utils/JarFileScanner.java
+++ b/src/main/java/org/codehaus/mojo/gwt/utils/JarFileScanner.java
@@ -1,6 +1,6 @@
 package org.codehaus.mojo.gwt.utils;
 
-import org.apache.commons.logging.Log;
+import org.apache.maven.plugin.logging.Log;
 import org.codehaus.plexus.util.AbstractScanner;
 
 /*

--- a/src/main/java/org/codehaus/mojo/gwt/utils/JarFileScanner.java
+++ b/src/main/java/org/codehaus/mojo/gwt/utils/JarFileScanner.java
@@ -1,8 +1,5 @@
 package org.codehaus.mojo.gwt.utils;
 
-import org.apache.maven.plugin.logging.Log;
-import org.codehaus.plexus.util.AbstractScanner;
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -21,17 +18,14 @@ import org.codehaus.plexus.util.AbstractScanner;
  * specific language governing permissions and limitations
  * under the License.
  */
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+
+import java.io.*;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
 
-import cern.colt.Arrays;
+import org.codehaus.plexus.util.AbstractScanner;
 
 /**
  * Scans jar files.
@@ -42,13 +36,11 @@ public final class JarFileScanner extends AbstractScanner
 {
     private final File jarFile;
     private final Set<String> matchingEntries;
-    private final Log log;
 
-    public JarFileScanner( File jarFile, Log log )
+    public JarFileScanner( File jarFile )
     {
         this.jarFile = jarFile;
         this.matchingEntries = new HashSet<String>();
-        this.log = log;
     }
 
     public String[] getIncludedFiles()
@@ -102,22 +94,6 @@ public final class JarFileScanner extends AbstractScanner
                 if ( !isExcluded( entryName ) )
                 {
                     matchingEntries.add(entryName);
-                }
-                else
-                {
-                    if (log.isDebugEnabled())
-                    {
-                        log.debug("entry " + entryName + " rejected; includes: " + Arrays.toString(
-                            includes) + "; excludes: " + Arrays.toString(excludes));
-                    }
-                }
-            }
-            else
-            {
-                if (log.isDebugEnabled())
-                {
-                    log.debug("entry " + entryName + " rejected; includes: " + Arrays.toString(
-                        includes) + "; excludes: " + Arrays.toString(excludes));
                 }
             }
             jarInputStream.closeEntry();

--- a/src/main/java/org/codehaus/mojo/gwt/utils/JarFileScanner.java
+++ b/src/main/java/org/codehaus/mojo/gwt/utils/JarFileScanner.java
@@ -96,7 +96,7 @@ public final class JarFileScanner extends AbstractScanner
             // replace all "/" characters in the JAR's entry name by the platform-specific
             // File.separator because the patterns against which the entry name will be matched
             // has undergone the same transformation already
-            String entryName = jarEntry.getName().replaceAll("/", File.separator);
+            String entryName = jarEntry.getName().replaceAll("/", File.separatorChar == '\\' ? "\\\\" : File.separator);
             if ( isIncluded( entryName ) )
             {
                 if ( !isExcluded( entryName ) )

--- a/src/main/java/org/codehaus/mojo/gwt/utils/JarFileScanner.java
+++ b/src/main/java/org/codehaus/mojo/gwt/utils/JarFileScanner.java
@@ -93,7 +93,10 @@ public final class JarFileScanner extends AbstractScanner
         JarEntry jarEntry;
         while ( ( jarEntry = jarInputStream.getNextJarEntry() ) != null )
         {
-            String entryName = jarEntry.getName();
+            // replace all "/" characters in the JAR's entry name by the platform-specific
+            // File.separator because the patterns against which the entry name will be matched
+            // has undergone the same transformation already
+            String entryName = jarEntry.getName().replaceAll("/", File.separator);
             if ( isIncluded( entryName ) )
             {
                 if ( !isExcluded( entryName ) )

--- a/src/main/java/org/codehaus/mojo/gwt/utils/ProjectScanner.java
+++ b/src/main/java/org/codehaus/mojo/gwt/utils/ProjectScanner.java
@@ -121,7 +121,7 @@ public final class ProjectScanner extends AbstractScanner
                 log.debug( "Scanning: " + fileOrDirectory.getPath() );
             }
 
-            AbstractScanner scanner = scannerFor( fileOrDirectory );
+            AbstractScanner scanner = scannerFor( fileOrDirectory, log );
             scanner.setIncludes( includes );
             scanner.setExcludes( excludes );
             scanner.scan();
@@ -142,7 +142,7 @@ public final class ProjectScanner extends AbstractScanner
         }
     }
 
-    private AbstractScanner scannerFor( File fileOrDirectory )
+    private AbstractScanner scannerFor( File fileOrDirectory, Log log )
             throws FileNotFoundException, IllegalArgumentException {
         if ( !fileOrDirectory.exists() )
         {
@@ -156,7 +156,7 @@ public final class ProjectScanner extends AbstractScanner
         }
         else if ( fileOrDirectory.getName().endsWith( ".jar") )
         {
-            return new JarFileScanner( fileOrDirectory );
+            return new JarFileScanner( fileOrDirectory, log );
         }
         else
         {

--- a/src/main/java/org/codehaus/mojo/gwt/utils/ProjectScanner.java
+++ b/src/main/java/org/codehaus/mojo/gwt/utils/ProjectScanner.java
@@ -101,7 +101,6 @@ public final class ProjectScanner extends AbstractScanner
         Collection<File> directories = new LinkedList<File>();
         if ( project != null )
         {
-            @SuppressWarnings("unchecked")
             Collection<String> roots = (Collection<String>) project.getCompileSourceRoots();
             for ( String root : roots )
             {
@@ -121,7 +120,7 @@ public final class ProjectScanner extends AbstractScanner
                 log.debug( "Scanning: " + fileOrDirectory.getPath() );
             }
 
-            AbstractScanner scanner = scannerFor( fileOrDirectory, log );
+            AbstractScanner scanner = scannerFor( fileOrDirectory );
             scanner.setIncludes( includes );
             scanner.setExcludes( excludes );
             scanner.scan();
@@ -142,7 +141,7 @@ public final class ProjectScanner extends AbstractScanner
         }
     }
 
-    private AbstractScanner scannerFor( File fileOrDirectory, Log log )
+    private AbstractScanner scannerFor( File fileOrDirectory )
             throws FileNotFoundException, IllegalArgumentException {
         if ( !fileOrDirectory.exists() )
         {
@@ -156,7 +155,7 @@ public final class ProjectScanner extends AbstractScanner
         }
         else if ( fileOrDirectory.getName().endsWith( ".jar") )
         {
-            return new JarFileScanner( fileOrDirectory, log );
+            return new JarFileScanner( fileOrDirectory );
         }
         else
         {


### PR DESCRIPTION
Solves issue #173 (https://github.com/gwt-maven-plugin/gwt-maven-plugin/issues/173)

On Windows with Cygwin tests fail due to "\" being the file separator. This commit fixes this by abstracting the test verdict to use File.separator instead of hard-coding "/". Furthermore, searching artifacts on Windows in JAR files suffered from a mismatch between the constant, platform-agnostic use of "/" in JAR file entry names and the platform-specific use of search pattern file separators ("\" on Windows). As a drive-by improvement, for slower machines, this PR also increases the timeout for the gwt-test-fail integration test which on slower platforms fails for timeouts.