### PR TITLE
Support plugin-dependencies during test phase

### DIFF
--- a/src/main/java/org/codehaus/mojo/gwt/shell/TestMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/TestMojo.java
@@ -19,9 +19,12 @@ package org.codehaus.mojo.gwt.shell;
  * under the License.
  */
 
+import java.util.List;
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -454,6 +457,15 @@ public class TestMojo
                 }
 
                 addCompileSourceArtifacts( cmd );
+
+                // Adding explicitly defined plugin-dependencies to classpath
+                List<Dependency> dependencies = ((PluginDescriptor) this.getPluginContext().get("pluginDescriptor")).getPlugin().getDependencies();
+                getLog().info("Adding explicitly defined plugin-dependencies to classpath: " + dependencies.toString());
+                for (Dependency dependency : dependencies)
+                {
+                    Collection<File> jarFiles = getJarFiles(dependency.getGroupId() + ":" + dependency.getArtifactId(), false);
+                    cmd.addToClasspath(jarFiles);
+                }
 
                 cmd.arg( test );
                 cmd.systemProperty( "surefire.reports", reportsDirectory.getAbsolutePath() );


### PR DESCRIPTION
We recently switched to Spring 6 / Jakarta and removed all javax dependencies. 
Running GWT Tests uses Jetty 9 and so still needs dependencies to javax. Additionally `com.google.gwt.junit.JUnitShell` from gwt-user uses javax-servlet dependencies.

To accomodate this, it should be possible to run the plugin in test phase with additional plugin dependencies.
e.g.:

```
<plugin>
	<groupId>org.codehaus.mojo</groupId>
	<artifactId>gwt-maven-plugin</artifactId>
	<dependencies>
		<dependency>
			<groupId>javax.servlet</groupId>
			<artifactId>javax.servlet-api</artifactId>
			<version>4.0.1</version>
		</dependency>
		<dependency>
			<groupId>javax.annotation</groupId>
			<artifactId>javax.annotation-api</artifactId>
			<version>1.3.2</version>
		</dependency>
	</dependencies>
</plugin>
```
